### PR TITLE
Fix input variables and some READMEs

### DIFF
--- a/clouds/azure/README.md
+++ b/clouds/azure/README.md
@@ -56,17 +56,17 @@ The `clouds` module is designed to integrate with Terraform's backend configurat
 
 You can use a separate Terraform module (`clouds/azure/state`) to provision the Azure Storage Account and container required for the Terraform state backend.
 
-1. Create the azure storage account where the TF state will be saved
+1. Create the azure storage account where the terraform state will be saved
 ```shell
 pushd clouds/azure/state
 
 # TODO for users: change the value set in the `storage_account_name` key of the backend resource to a bucket name of your choice
-tf init 
+terraform init 
 
-tf plan -out terraform.out \
+terraform plan -out terraform.out \
     -var="AZURE_SUBSCRIPTION_ID=mySubscriptionId"  # required, your Azure subscription ID
 
-tf apply terraform.out
+terraform apply terraform.out
 
 popd
 ```
@@ -97,9 +97,9 @@ Example `clouds/azure/versions.tf` snippet for backend configuration:
 ```shell
 pushd clouds/azure
 
-tf init 
+terraform init 
 
-tf plan -out terraform.out \
+terraform plan -out terraform.out \
     -var="RESOURCE_GROUP_NAME=myResourceGroup"    \  # optional, defaults to "main-rg"
     -var="REGION=eastus"                          \  # optional, defaults to "eastus
     -var="AZURE_SUBSCRIPTION_ID=mySubscriptionId" \  # required, your Azure subscription ID
@@ -110,7 +110,7 @@ tf plan -out terraform.out \
     -var="AKS_CLUSTER_NAME=myAKSCluster"          \  # optional, defaults to "aks-cluster", set to "" if you do not want to provision an AKS cluster
     -var="SETUP_LOCAL_HOST=false"                 \  # optional, defaults to false, set to true if you don't want a bastion and you want to set up the local host with Juju and deploy the controller
 
-tf apply terraform.out
+terraform apply terraform.out
 
 popd
 ```

--- a/clouds/azure/state/README.md
+++ b/clouds/azure/state/README.md
@@ -28,5 +28,9 @@ To use this module, run the following command in your terminal:
 
 ```bash
 terraform init
-terraform apply -var="RESOURCE_GROUP_NAME=myResourceGroup" -var="REGION=eastus" -var="AZURE_SUBSCRIPTION_ID=mySubscriptionId" -var="STORAGE_ACCOUNT_NAME=myStorageAccount"
+terraform apply \
+  -var="RESOURCE_GROUP_NAME=myResourceGroup" \
+  -var="REGION=eastus" \
+  -var="AZURE_SUBSCRIPTION_ID=mySubscriptionId" \
+  -var="STORAGE_ACCOUNT_NAME=myStorageAccount"
 ```

--- a/solutions/data/charmed-etcd/azure/vm/README.md
+++ b/solutions/data/charmed-etcd/azure/vm/README.md
@@ -53,7 +53,10 @@ Once your Terraform configuration is set up, execute the following commands in y
 2.  **Plan the Deployment**: Review the changes Terraform will apply. This is a crucial step to understand the impact of your configuration.
 
     ```bash
-    terraform plan
+    terraform plan -out terraform.out \
+      -var='etcd={}'                  \
+      -var='backups-integrator={"storage_type": "azure-storage", "config": {"storage-account": "stoacc", "container": "conn"}}' \
+      -var='remote-state={"storage_account_name": "<CHANGE_ME>"}'  # TODO change this to the name of the storage_account_name you've been using to store the state
     ```
 
 3.  **Apply the Configuration**: This command executes the planned actions and deploys the charmed etcd solution.

--- a/solutions/data/charmed-etcd/azure/vm/main.tf
+++ b/solutions/data/charmed-etcd/azure/vm/main.tf
@@ -29,7 +29,6 @@ module "cos" {
   source  = "git::https://github.com/canonical/observability-stack//terraform/cos-lite"
   model   = var.cos.model
   channel = var.cos.channel
-  use_tls = var.cos.use_tls
 
   depends_on = [
     juju_model.k8s_model,

--- a/solutions/data/charmed-etcd/azure/vm/variables.tf
+++ b/solutions/data/charmed-etcd/azure/vm/variables.tf
@@ -5,13 +5,10 @@ variable "cos" {
   description = "Configuration for the Charmed Observability Stack (COS)"
   type = object({
     model   = optional(string, "k8s")
-    channel = optional(string, "2/edge")
-    use_tls = optional(bool, false)
+    channel = optional(string, null)
   })
   default = {
     model   = "k8s"
-    channel = "2/edge"
-    use_tls = false
   }
 }
 
@@ -30,6 +27,7 @@ variable "etcd" {
     storage           = optional(map(string), {})
     endpoint_bindings = optional(map(string), {})
     expose            = optional(bool, false)
+    tls               = optional(bool, false)
   })
 }
 
@@ -48,7 +46,7 @@ variable "backups-integrator" {
 
   validation {
     condition     = contains(["s3", "azure-storage"], var.backups-integrator.storage_type)
-    error_message = "backup-integrator allows one of the values: 's3', 'azure' for storage_type."
+    error_message = "backup-integrator allows one of the values: 's3', 'azure-storage' for storage_type."
   }
 
   validation {
@@ -113,9 +111,9 @@ variable "data-integrator" {
 variable "remote-state" {
   description = "Configuration for the remote state"
   type = object({
-    resource_group_name  = string
-    storage_account_name = string
+    resource_group_name  = optional(string, "tfstate-rg")
+    storage_account_name = optional(string, "tfstate")
     container_name       = string
-    key                  = string
+    key                  = optional(string, "infra.terraform.tfstate")
   })
 }


### PR DESCRIPTION
This PR: 
- fixes wrong input variables in the COS module (`use_tls`)
- fixes wrong channel set in the COS object
- sets default values to the `remote-state` variable and 
- adds the `tls` flag on etcd object
- fixes the error message on backups integrator input validation
- adds examples on how to deploy charmed-etcd