### PR TITLE
fix remote-state variable

### DIFF
--- a/solutions/data/charmed-etcd/azure/vm/variables.tf
+++ b/solutions/data/charmed-etcd/azure/vm/variables.tf
@@ -112,8 +112,8 @@ variable "remote-state" {
   description = "Configuration for the remote state"
   type = object({
     resource_group_name  = optional(string, "tfstate-rg")
-    storage_account_name = optional(string, "tfstate")
-    container_name       = string
+    storage_account_name = string
+    container_name       = optional(string, "tfstate")
     key                  = optional(string, "infra.terraform.tfstate")
   })
 }


### PR DESCRIPTION
* [`solutions/data/charmed-etcd/azure/vm/variables.tf`](diffhunk://#diff-96b736be03456ff88fac3131a0a24b3dce12a0f51c8552c734803ea97a5a30c0L115-R116): Changed `storage_account_name` to be a required field (removed default value) and made `container_name` optional with a default value of `"tfstate"`. This ensures that the storage account name must be explicitly provided while simplifying the configuration for the container name.